### PR TITLE
Add SEO metadata and sitemap

### DIFF
--- a/project/index.html
+++ b/project/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Premium pet cooling mats keep pets comfortable for hours on hot days." />
+    <link rel="canonical" href="https://example.com/" />
+    <meta name="robots" content="index, follow" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://images.pexels.com data:;" />
     <meta name="p:domain_verify" content="d1c7312bcba71fe73978143a9af0c5df"/>
     <!-- Google tag (gtag.js) -->

--- a/project/public/robots.txt
+++ b/project/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://example.com/sitemap.xml

--- a/project/public/sitemap.xml
+++ b/project/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add meta description, canonical and robots tags
- create `sitemap.xml` and `robots.txt`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418050697483339b9c508c063a7708